### PR TITLE
Update wp web push

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "wp-web-push"]
 	path = wp-web-push
-	url = https://github.com/marco-c/wp-web-push.git
+	url = https://github.com/mozilla/wp-web-push.git
 [submodule "offline-shell"]
 	path = offline-shell
 	url = git@github.com:mozilla/wp-offline-shell.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM wordpress:latest
 # Install the Debian packages we need to build/install other software.
 RUN apt-get update && apt-get install -y \
     git \
+    node \
     npm \
     unzip \
     wget \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update && apt-get install -y \
 # Build and install wp-web-push.
 COPY wp-web-push /var/tmp/wp-web-push
 RUN cd /var/tmp/wp-web-push/ \
+    && make tools/composer.phar \
+    && tools/composer.phar update \
     && make build \
     && unzip wp-web-push.zip -d /usr/src/wordpress/wp-content/plugins/wp-web-push \
     && rm -rf /var/tmp/wp-web-push

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 FROM wordpress:latest
 
 # Install the Debian packages we need to build/install other software.
+# We link /usr/local/bin/node to /usr/bin/nodejs to ensure it's available
+# at that name for Node scripts with `#!/usr/bin/env node` shebangs.
 RUN apt-get update && apt-get install -y \
     git \
     node \
@@ -10,7 +12,8 @@ RUN apt-get update && apt-get install -y \
     wget \
     zip \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/bin/nodejs /usr/local/bin/node
 
 # Build and install wp-web-push.
 COPY wp-web-push /var/tmp/wp-web-push


### PR DESCRIPTION
@marco-c After I updated to the tip of wp-web-push, I started getting:

>tools/composer.phar install
>Loading composer repositories with package information
>Installing dependencies (including require-dev) from lock file
>Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. Run update to update them.
>Nothing to install or update
>Generating autoload files
>cp: cannot stat 'vendor/marco-c/wp_serve_file/class-wp-serve-file.php': No such file or directory
>make: *** [build] Error 1

So I added commands to the Dockerfile to call `composer update`. Now I'm getting:

>Loading composer repositories with package information
>Failed to clone the git@github.com:marco-c/wp-web-app-manifest-generator.git repository, try running in interactive mode >so that you can enter your GitHub credentials>
>
>  [RuntimeException]
>  Failed to execute git clone --mirror 'git@github.com:marco-c/wp-web-app-manifest-generator.git' '/root/.composer/cache/>vcs/git-github.com-marco-c-wp-web-app-manifest-generator.git/'  
>  fatal: Not a git repository: ../.git/modules/wp-web-push

Any idea what might be going wrong?
